### PR TITLE
Exclude npmjs.com from lychee link check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Check links in markdown files
         uses: lycheeverse/lychee-action@v2
         with:
-          args: "--verbose --no-progress --root-dir docs --exclude-path 'docs/includes.md' --exclude 'http://127*' --exclude 'http://localhost' './docs/**/*.md'"
+          args: "--verbose --no-progress --root-dir docs --exclude-path 'docs/includes.md' --exclude 'http://127*' --exclude 'http://localhost' --exclude 'npmjs\\.com' './docs/**/*.md'"
           fail: true
 
   deploy:


### PR DESCRIPTION
npmjs.com returns 403 Forbidden to lychee's CI requests (bot protection), even though the package URL works in a browser. Exclude it to avoid a false-positive broken-link failure.